### PR TITLE
chore(API documentation): add API documentation of endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Quick Credit is an online lending platform that provides short term soft loans t
 - [Introduction](#introduction)
 - [UI Templates](#ui-templates)
 - [API](#api)
+- [API Documentation](#api-documentation)
 - [Pivotal Tracker ID](https://www.pivotaltracker.com/n/projects/2326723)
 - [Technologies](#technologies)
 - [Installing](#installing)
@@ -41,6 +42,10 @@ Preview UI templates :+1: [Github Pages](/)
 # API
 
 The API is currently in version 1 (v1) and is hosted at https://quick-credit-loan.herokuapp.com
+
+# API-Documentation
+
+The API endpoints are documented using swagger.json and can be accessed here [API-Docs](https://app.swaggerhub.com/apis-docs/mekzy4/Quick-Credit/1.0.0)
 
 # Pivotal Tracker ID
 
@@ -114,10 +119,11 @@ To run test cases
 | /api/v1/loans?_status=approved&repaid=false_ | View all current loans(not fully repaid) |         GET |
 | /api/v1/loans?_status=approved&repaid=true_  |      View all current repaid loans       |         GET |
 | /api/v1/loan/_loan_id_                       |          Reject or approve loan          |       PATCH |
-| /api/v1/_loan_id_/repayment                 |        Create a repayment record         |        POST |
+| /api/v1/_loan_id_/repayment                  |        Create a repayment record         |        POST |
 | /api/v1/users/password                       |              Reset Pasword               |        POST |
 | /api/v1/users/                               |              Get All Users               |         GET |
 | /api/v1/users/:email                         |            Get A Single User             |         GET |
+| /api/v1/docs                                 |          Read API documentation          |         GET |
 
 ## License :boom:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6674,6 +6674,19 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-ui-dist": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.1.tgz",
+      "integrity": "sha512-KITbEqXkXrjGH12A0lpVZlH3uODFkwUh8d15My1YD4N0PSZDnIiC1iMFT6ryyuJxDYWZh0qezKpPqa5FRowngw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.2.tgz",
+      "integrity": "sha512-XZtXI2+SKT3fgvJSGg4P7Dtmkzr50uoSb09IxbUWmjL538TIGRMZtfdEkjZEEq44xgGNAxMryzBEUdUnkXr8dA==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "table": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "mocha": "^6.1.4",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
-    "nodemailer": "^6.1.1"
+    "nodemailer": "^6.1.1",
+    "swagger-ui-express": "^4.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import expressValidator from 'express-validator';
+import swaggerUi from 'swagger-ui-express';
+import swaggerDoc from '../../swagger.json';
 import UserController from '../controllers/userController';
 import LoanController from '../controllers/loanController';
 import RepaymentController from '../controllers/repaymentController';
@@ -11,6 +13,8 @@ import Authorization from '../auth/authorization';
 const router = express.Router();
 
 router.use(expressValidator());
+
+router.use('/api/v1/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 
 const {
  userSignup, userLogin, adminVerifyUser, resetPassword, getAllUsers, getSingleUser 

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,1008 @@
+{
+  "swagger" : "2.0",
+  "host" : "quick-credit-loan.herokuapp.com",
+  "basePath" : "/api/v1",
+  "schemes" : [ "https" ],
+  "info" : {
+    "version" : "1.0.0",
+    "title" : "Quick-Credit API V1",
+    "description" : "An  online lending platform that provides short term soft loans to individuals. This helps solve problems of financial inclusion as a way to alleviate poverty",
+    "contact" : {
+      "email" : "emekaofe22@gmail.com"
+    }
+  },
+  "consumes" : [ "application/x-www-form-urlencoded", "application/json" ],
+  "produces" : [ "application/json" ],
+  "securityDefinitions" : {
+    "Bearer" : {
+      "type" : "apiKey",
+      "name" : "Authorization",
+      "in" : "header"
+    }
+  },
+  "paths" : {
+    "/auth/signup" : {
+      "post" : {
+        "tags" : [ "authentication" ],
+        "description" : "Creates an account for a new user",
+        "summary" : "User sign up",
+        "operationId" : "ApiV1AuthSignupPost",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "user",
+          "description" : "The user object",
+          "schema" : {
+            "type" : "object",
+            "required" : [ "firstName", "lastName", "email", "password", "address" ],
+            "properties" : {
+              "firstName" : {
+                "type" : "string"
+              },
+              "lastName" : {
+                "type" : "string"
+              },
+              "email" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "address" : {
+                "type" : "string"
+              }
+            }
+          }
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "User Account created successfully",
+            "schema" : {
+              "$ref" : "#/definitions/userSignupResponse"
+            },
+            "headers" : { }
+          },
+          "409" : {
+            "description" : "Email already exists (Unprocessible entity)",
+            "schema" : {
+              "$ref" : "#/definitions/userExists"
+            }
+          }
+        }
+      }
+    },
+    "/auth/signin" : {
+      "post" : {
+        "tags" : [ "authentication" ],
+        "description" : "Logs into an account of existing user",
+        "summary" : "User sign in",
+        "operationId" : "ApiV1AuthSigninPost",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "userLogin",
+          "description" : "The user object",
+          "schema" : {
+            "type" : "object",
+            "required" : [ "firstName", "lastName", "email", "password", "address" ],
+            "properties" : {
+              "email" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              }
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Login Successful",
+            "schema" : {
+              "$ref" : "#/definitions/userSignupResponse"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "404" : {
+            "description" : "Email Address not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/loans" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Creates a loan application for user",
+        "summary" : "Create a loan application",
+        "operationId" : "ApiV1LoanApply",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "loan details",
+          "description" : "Details for the new loans",
+          "schema" : {
+            "type" : "object",
+            "required" : [ "firstName", "lastName", "email", "amount", "tenor" ],
+            "properties" : {
+              "firstName" : {
+                "type" : "string"
+              },
+              "lastName" : {
+                "type" : "string"
+              },
+              "email" : {
+                "type" : "string"
+              },
+              "amount" : {
+                "type" : "number"
+              },
+              "tenor" : {
+                "type" : "integer"
+              }
+            }
+          }
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "Loan application created successfully",
+            "schema" : {
+              "$ref" : "#/definitions/newLoanApplication"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "View a list of all user loans.",
+        "summary" : "Get all user loan details",
+        "operationId" : "ApiV1GetAllLoan",
+        "deprecated" : false,
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Loan application fetched Successfully",
+            "schema" : {
+              "$ref" : "#/definitions/newLoanData"
+            },
+            "headers" : { }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          }
+        }
+      }
+    },
+    "/loans/{id}" : {
+      "patch" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Change the user loan status",
+        "summary" : "Change loan status",
+        "operationId" : "ApiV1StatusUpdate",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "type" : "integer",
+          "description" : "The id of the loan to be updated"
+        }, {
+          "in" : "body",
+          "name" : "status",
+          "description" : "status for the loan to be updated",
+          "schema" : {
+            "type" : "object",
+            "required" : [ "status" ],
+            "properties" : {
+              "status" : {
+                "type" : "string"
+              }
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "loan updated successfully",
+            "schema" : {
+              "$ref" : "#/definitions/approveRejectLoan"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "403" : {
+            "description" : "Access token does not have the required scope",
+            "schema" : {
+              "$ref" : "#/definitions/forbiddenError"
+            }
+          },
+          "404" : {
+            "description" : "loan Id not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Get a specific loan data",
+        "summary" : "Get loan data",
+        "deprecated" : false,
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "type" : "integer",
+          "description" : "The loan admin wants to get"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "loan retrieved successfully",
+            "schema" : {
+              "$ref" : "#/definitions/newLoanData"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "403" : {
+            "description" : "Access token does not have the required scope",
+            "schema" : {
+              "$ref" : "#/definitions/forbiddenError"
+            }
+          },
+          "404" : {
+            "description" : "Loan Id not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/loans/{id}/repayment" : {
+      "post" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Post a repayment in favour of client",
+        "summary" : "Admin post user's paid amount",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "type" : "integer",
+          "description" : "The loan to post the paid amount"
+        }, {
+          "in" : "body",
+          "name" : "transaction details",
+          "description" : "The Amount client paid",
+          "schema" : {
+            "type" : "object",
+            "required" : [ "paidAmount" ],
+            "properties" : {
+              "amount" : {
+                "type" : "number"
+              }
+            }
+          }
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "Amount posted successfully",
+            "schema" : {
+              "$ref" : "#/definitions/loanRepayment"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "403" : {
+            "description" : "Access token does not have the required scope",
+            "schema" : {
+              "$ref" : "#/definitions/forbiddenError"
+            }
+          },
+          "404" : {
+            "description" : "Loan Id not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/loans/{id}/repayments" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Get user repayment history",
+        "summary" : "Get all user repayments for specific loan",
+        "operationId" : "ApiV1getRepayments",
+        "deprecated" : false,
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "type" : "integer",
+          "description" : "The loan repayment history to fetch"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "repayment history fetched successfully",
+            "schema" : {
+              "$ref" : "#/definitions/getRepayments"
+            },
+            "headers" : { }
+          },
+          "400" : {
+            "description" : "Bad request",
+            "schema" : {
+              "$ref" : "#/definitions/badRequest"
+            }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "404" : {
+            "description" : "Loan Id not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/loans/status=approved&&repaid=true" : {
+      "get" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "View history of loans that are repaid",
+        "summary" : "View all repaid loans",
+        "operationId" : "ApiV1viewRepaidLoans",
+        "deprecated" : false,
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Repaid loans fetched successfully",
+            "schema" : {
+              "$ref" : "#/definitions/getCurrentLoans"
+            },
+            "headers" : { }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "404" : {
+            "description" : "Loan not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/loans/status=approved&&repaid=false" : {
+      "get" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "View history of loans that are not repaid",
+        "summary" : "View all current loans",
+        "operationId" : "ApiV1viewcurrentLoans",
+        "deprecated" : false,
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "Current loans fetched successfully",
+            "schema" : {
+              "$ref" : "#/definitions/getCurrentLoans"
+            },
+            "headers" : { }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "404" : {
+            "description" : "Loans not found",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    },
+    "/users/{user-email-address}/verify" : {
+      "patch" : {
+        "tags" : [ "admin" ],
+        "security" : [ {
+          "Bearer" : [ ]
+        } ],
+        "description" : "Verify user account",
+        "summary" : "Verify user on confirmation of home address",
+        "deprecated" : false,
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "user-email-address",
+          "required" : true,
+          "type" : "string",
+          "description" : "The email of the user whose accounts admin wants to verify"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "User email verified successfully",
+            "schema" : {
+              "$ref" : "#/definitions/userSignupResponse"
+            },
+            "headers" : { }
+          },
+          "401" : {
+            "description" : "Authentication error",
+            "schema" : {
+              "$ref" : "#/definitions/UnauthorizedError"
+            }
+          },
+          "404" : {
+            "description" : "User Email does not Exist",
+            "schema" : {
+              "$ref" : "#/definitions/userNotFound"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "userSignupResponse" : {
+      "title" : "userSignupResponse",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64"
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/signUp"
+          }
+        }
+      }
+    },
+    "signUp" : {
+      "title" : "signUp",
+      "type" : "object",
+      "properties" : {
+        "token" : {
+          "type" : "string"
+        },
+        "id" : {
+          "type" : "number",
+          "format" : "int64"
+        },
+        "firstname" : {
+          "type" : "string"
+        },
+        "lastname" : {
+          "type" : "string"
+        },
+        "email" : {
+          "type" : "string"
+        },
+        "address" : {
+          "type" : "string"
+        },
+        "status" : {
+          "type" : "string"
+        },
+        "isadmin" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "userExists" : {
+      "title" : "userExists",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 409
+        },
+        "error" : {
+          "type" : "string"
+        }
+      }
+    },
+    "userNotFound" : {
+      "title" : "userNotFound",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 404
+        },
+        "error" : {
+          "type" : "string"
+        }
+      }
+    },
+    "badRequest" : {
+      "title" : "badRequest",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 400
+        },
+        "error" : {
+          "type" : "string"
+        }
+      }
+    },
+    "UnauthorizedError" : {
+      "title" : "noAuth",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 401
+        },
+        "error" : {
+          "type" : "string"
+        }
+      }
+    },
+    "forbiddenError" : {
+      "title" : "forbidden",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 403
+        },
+        "error" : {
+          "type" : "string"
+        }
+      }
+    },
+    "newLoanApplication" : {
+      "title" : "newLoanApplication",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 201
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/newLoanData"
+          }
+        }
+      }
+    },
+    "newLoanData" : {
+      "title" : "newLoanData",
+      "type" : "object",
+      "properties" : {
+        "loanId" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 5
+        },
+        "firstname" : {
+          "type" : "string"
+        },
+        "lastname" : {
+          "type" : "string"
+        },
+        "email" : {
+          "type" : "string"
+        },
+        "amount" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "tenor" : {
+          "type" : "number",
+          "format" : "integer",
+          "example" : 10
+        },
+        "paymentInstallment" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000.0
+        },
+        "status" : {
+          "type" : "string"
+        },
+        "balance" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000.0
+        },
+        "interest" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 1000.5
+        }
+      }
+    },
+    "approveRejectLoan" : {
+      "title" : "approve/RejectLoan",
+      "type" : "object",
+      "properties" : {
+        "loanId" : {
+          "type" : "string",
+          "format" : "integer",
+          "example" : 1
+        },
+        "loanAmount" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "tenor" : {
+          "type" : "number",
+          "format" : "integer",
+          "example" : 1
+        },
+        "status" : {
+          "type" : "string",
+          "example" : "approve or reject"
+        },
+        "monthlyInstallment" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "interest" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 1000
+        }
+      }
+    },
+    "loanRepayment" : {
+      "title" : "post repayment transaction",
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 1
+        },
+        "loanId" : {
+          "type" : "string",
+          "format" : "int64",
+          "example" : 1
+        },
+        "createdOn" : {
+          "type" : "string",
+          "format" : "date-time",
+          "example" : "2017-07-21T17:32:28Z"
+        },
+        "Amount" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "monthlyInstallments" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "paidAmount" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 10000
+        },
+        "balance" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 1000
+        }
+      }
+    },
+    "getRepayments" : {
+      "title" : "View repayment history",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 200
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/repayments"
+          }
+        }
+      },
+      "repayments" : {
+        "title" : "User Repayments",
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "number",
+            "format" : "int64",
+            "example" : 1
+          },
+          "loanId" : {
+            "type" : "string",
+            "format" : "int64",
+            "example" : 1
+          },
+          "createdOn" : {
+            "type" : "string",
+            "format" : "date-time",
+            "example" : "2017-07-21T17:32:28Z"
+          },
+          "Amount" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 10000
+          },
+          "monthlyInstallments" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 10000
+          },
+          "paidAmount" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 10000
+          },
+          "balance" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 1000
+          }
+        }
+      },
+      "getLoans" : {
+        "title" : "Get All loans",
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "number",
+            "format" : "int64",
+            "example" : 200
+          },
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/newLoanData"
+            }
+          }
+        }
+      },
+      "loans" : {
+        "title" : "User loans",
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "number",
+            "format" : "int64",
+            "example" : 1
+          },
+          "user" : {
+            "type" : "email",
+            "example" : "smaple@mail.com"
+          },
+          "createdOn" : {
+            "type" : "string",
+            "format" : "date-time",
+            "example" : "2017-07-21T17:32:28Z"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "repaid" : {
+            "type" : "boolean",
+            "example" : "true or false"
+          },
+          "tenor" : {
+            "type" : "number",
+            "format" : "int64",
+            "example" : 12
+          },
+          "amount" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 25000.58
+          },
+          "paymentInstallment" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 50000.58
+          },
+          "balance" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 50000.58
+          },
+          "interest" : {
+            "type" : "number",
+            "format" : "float",
+            "example" : 50000.58
+          }
+        }
+      }
+    },
+    "getCurrentLoans" : {
+      "title" : "Get loans not repaid",
+      "type" : "object",
+      "properties" : {
+        "status" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 200
+        },
+        "data" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/currentloans"
+          }
+        }
+      }
+    },
+    "currentloans" : {
+      "title" : "Get current Loans",
+      "type" : "object",
+      "properties" : {
+        "Id" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 1
+        },
+        "user" : {
+          "type" : "string",
+          "example" : "smaple@mail.com"
+        },
+        "createdOn" : {
+          "type" : "string",
+          "format" : "date-time",
+          "example" : "2017-07-21T17:32:28Z"
+        },
+        "status" : {
+          "type" : "string"
+        },
+        "repaid" : {
+          "type" : "boolean",
+          "example" : false
+        },
+        "tenor" : {
+          "type" : "number",
+          "format" : "int64",
+          "example" : 12
+        },
+        "amount" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 25000.58
+        },
+        "paymentInstallment" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 50000.58
+        },
+        "balance" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 50000.58
+        },
+        "interest" : {
+          "type" : "number",
+          "format" : "float",
+          "example" : 50000.58
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

- Document API endpoints

**Description of Task to be completed?** 

- Have the following endpoint working that allows access to documentation:
 `GET /api/v1/docs` ||  `POST /api/v1/docs`


**How should this be manually tested?**
- git fetch
- git checkout ch-api-documentation-165940159
- npm start-dev
- Open browser and run endpoint using localhost to access documentation

**What are the relevant pivotal tracker stories?**

https://www.pivotaltracker.com/story/show/165940159